### PR TITLE
add CI on self-hosted Ubuntu 22.04 / amd64

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,102 @@
+name: build-linux
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '.github/workflows/*macos.yml'
+      - 'docs/**'
+      - '.clang-format'
+      - '.gitignore'
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/*macos.yml'
+      - 'docs/**'
+      - '.clang-format'
+      - '.gitignore'
+      - 'README.md'
+
+concurrency:
+  group: ${{
+    ( github.ref == 'refs/heads/master' &&
+    format('{0}/{1}', github.run_id, github.run_attempt) )
+    ||
+    format('{0}/{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    runs-on: [ self-hosted, Linux, amd64 ]
+
+    env:
+      CONTAINER_TMP: /opt/
+      HOST_TMP: /home/runner/work/_temp/
+      DEBIAN_FRONTEND: noninteractive
+      BOOST_VERSION: "1.80.0"
+
+    container:
+      image: ubuntu:22.04
+      volumes:
+        - /home/runner/work/_temp/:/opt/
+
+    steps:
+      - name: Install dependencies
+        run: |
+          env && \
+          apt update && \
+          apt install -y \
+            build-essential \
+            libssl-dev \
+            cmake \
+            python3.10 \
+            git
+
+      - name: Print toolchain information
+        run: |
+          git --version
+          cc --version
+          cmake --version    
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
+        id: install-boost
+        with:
+            # A list of supported versions can be found here:
+            # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
+            boost_version: ${{ env.BOOST_VERSION }}
+            boost_install_dir: ${{ env.CONTAINER_TMP }}
+            platform_version: 22.04
+            toolset: gcc
+            arch: x86
+
+      - name: Configure CMake
+        env:
+          BOOST_ROOT: "${{ steps.install-boost.outputs.BOOST_ROOT }}"
+        run: |
+          cmake -G "Unix Makefiles" \
+            -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCIRCUIT_ASSEMBLY_OUTPUT=TRUE .
+
+      - name: Build zkllvm
+        run: |
+          make -C build assigner clang -j$(nproc)
+
+      - name: Build examples
+        run: |
+          make -C build circuit_examples -j$(nproc)
+          ls -al ./build/examples
+
+      - name: Build circuits
+        run: |
+          build/bin/assigner/assigner \
+            -b build/examples/arithmetics_example.ll \
+            -i examples/arithmetics.inp \
+            -t assignment.tbl \
+            -c circuit.crct

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # zkLLVM Circuit Compiler
 
+[![build-linux](https://github.com/NilFoundation/zkllvm/actions/workflows/build_linux.yml/badge.svg?branch=master)](
+https://github.com/NilFoundation/zkllvm/actions/workflows/build_linux.yml)
+
 [![Discord](https://img.shields.io/discord/969303013749579846.svg?logo=discord&style=flat-square)](https://discord.gg/KmTAEjbmM3)
 [![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=flat-square&logo=telegram&logoColor=dark)](https://t.me/nilfoundation)
 [![Twitter](https://img.shields.io/twitter/follow/nil_foundation)](https://twitter.com/nil_foundation)


### PR DESCRIPTION
### ci: add CI on self-hosted Ubuntu 22.04 / amd64

Build on a self-hosted runner with Ubuntu 22.04 on amd64 architecture.
Toolchain:
* GCC 11.3.0
* Boost 1.80.0, prebuilt with GCC

Readme preview: https://github.com/NilFoundation/zkllvm/tree/nickvolynkin/build-in-ci (note the badge, it will be green after merging this PR)

Resolves #2