### PR TITLE
Use protocol-independent paths to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,69 +1,69 @@
 [submodule "cmake-modules"]
 	path = cmake/modules
-	url = git@github.com:BoostCMake/cmake_modules.git
+	url = ../../BoostCMake/cmake_modules.git
 [submodule "crypto3-algebra"]
 	path = libs/crypto3/algebra
-	url = git@github.com:NilFoundation/crypto3-algebra.git
+	url = ../../NilFoundation/crypto3-algebra.git
 [submodule "crypto3-block"]
 	path = libs/crypto3/block
-	url = git@github.com:NilFoundation/crypto3-block.git
+	url = ../../NilFoundation/crypto3-block.git
 [submodule "crypto3-codec"]
 	path = libs/crypto3/codec
-	url = git@github.com:NilFoundation/crypto3-codec.git
+	url = ../../NilFoundation/crypto3-codec.git
 [submodule "crypto3-containers"]
 	path = libs/crypto3/containers
-	url = git@github.com:NilFoundation/crypto3-containers.git
+	url = ../../NilFoundation/crypto3-containers.git
 [submodule "crypto3-hash"]
 	path = libs/crypto3/hash
-	url = git@github.com:NilFoundation/crypto3-hash.git
+	url = ../../NilFoundation/crypto3-hash.git
 [submodule "crypto3-mac"]
 	path = libs/crypto3/mac
-	url = git@github.com:NilFoundation/crypto3-mac.git
+	url = ../../NilFoundation/crypto3-mac.git
 [submodule "crypto3-math"]
 	path = libs/crypto3/math
-	url = git@github.com:NilFoundation/crypto3-math.git
+	url = ../../NilFoundation/crypto3-math.git
 [submodule "crypto3-modes"]
 	path = libs/crypto3/modes
-	url = git@github.com:NilFoundation/crypto3-modes.git
+	url = ../../NilFoundation/crypto3-modes.git
 [submodule "crypto3-multiprecision"]
 	path = libs/crypto3/multiprecision
-	url = git@github.com:NilFoundation/crypto3-multiprecision.git
+	url = ../../NilFoundation/crypto3-multiprecision.git
 [submodule "crypto3-pkmodes"]
 	path = libs/crypto3/pkmodes
-	url = git@github.com:NilFoundation/crypto3-pkmodes.git
+	url = ../../NilFoundation/crypto3-pkmodes.git
 [submodule "crypto3-pkpad"]
 	path = libs/crypto3/pkpad
-	url = git@github.com:NilFoundation/crypto3-pkpad.git
+	url = ../../NilFoundation/crypto3-pkpad.git
 [submodule "crypto3-pubkey"]
 	path = libs/crypto3/pubkey
-	url = git@github.com:NilFoundation/crypto3-pubkey.git
+	url = ../../NilFoundation/crypto3-pubkey.git
 [submodule "crypto3-random"]
 	path = libs/crypto3/random
-	url = git@github.com:NilFoundation/crypto3-random.git
+	url = ../../NilFoundation/crypto3-random.git
 [submodule "crypto3-stream"]
 	path = libs/crypto3/stream
-	url = git@github.com:NilFoundation/crypto3-stream.git
+	url = ../../NilFoundation/crypto3-stream.git
 [submodule "crypto3-zk"]
 	path = libs/crypto3/zk
-    url = git@github.com:NilFoundation/crypto3-zk.git
+    url = ../../NilFoundation/crypto3-zk.git
 [submodule "marshalling"]
 	path = libs/crypto3/marshalling/core
-	url = git@github.com:NilFoundation/marshalling.git
+	url = ../../NilFoundation/marshalling.git
 [submodule "crypto3-zk-marshalling"]
 	path = libs/crypto3/marshalling/zk
-    url = git@github.com:NilFoundation/crypto3-zk-marshalling.git
+    url = ../../NilFoundation/crypto3-zk-marshalling.git
 [submodule "crypto3-algebra-marshalling"]
 	path = libs/crypto3/marshalling/algebra
-	url = git@github.com:NilFoundation/crypto3-algebra-marshalling.git
+	url = ../../NilFoundation/crypto3-algebra-marshalling.git
 [submodule "crypto3-multiprecision-marshalling"]
 	path = libs/crypto3/marshalling/multiprecision
-	url = git@github.com:NilFoundation/crypto3-multiprecision-marshalling.git
+	url = ../../NilFoundation/crypto3-multiprecision-marshalling.git
 [submodule "zkllvm-assigner"]
 	path = libs/assigner
-	url = git@github.com:NilFoundation/zkllvm-assigner.git
+	url = ../../NilFoundation/zkllvm-assigner.git
 [submodule "zkllvm-circifier"]
 	path = libs/circifier
-	url = git@github.com:NilFoundation/zkllvm-circifier.git
+	url = ../../NilFoundation/zkllvm-circifier.git
 [submodule "zkllvm-blueprint"]
 	path = libs/blueprint
-	url = git@github.com:NilFoundation/zkllvm-blueprint.git
+	url = ../../NilFoundation/zkllvm-blueprint.git


### PR DESCRIPTION
### Use protocol-independent paths to submodules

With paths like `../../NilFoundation/` submodules will be cloned with
the same protocol as used to clone the parent repository.

Unlike explicit SSH, it allows external contributors and CI servers
to clone this repository without having to use SSH keys.

Unlike explicit HTTPS, it allows our own developers to develop code
in submodules and push it to GitHub without having to enter usernames
and passwords every time or to store tokens on development machines.

Resolves #33

Check with

```
git clone https://github.com/NilFoundation/zkllvm.git \
  --recurse-submodules \
  --branch nickvolynkin/protocol-independent-submodules \
  zkllvm-https

git clone git@github.com:NilFoundation/zkllvm.git \
  --recurse-submodules \
  --branch nickvolynkin/protocol-independent-submodules \
  zkllvm-ssh

```

With `actions/checkout` in CI: https://github.com/NilFoundation/zkllvm/actions/runs/4253698858