### PR TITLE
Update file extensions in make scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Users can generate & inspect intermediate artifacts such as execution trace by r
 
 ```bash
 make -C ${ZKLLVM_BUILD:-build} circuit_examples -j$(nproc) 
-${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.bc -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas
+${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.ll -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas
 ```
 
 #### macOS
 ```bash
 make -C ${ZKLLVM_BUILD:-build} circuit_examples -j$(sysctl -n hw.logicalcpu)
-${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.bc -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas
+${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.ll -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas
 ```


### PR DESCRIPTION
Very confusing and blocking make instructions use old file extensions. Let's change it.