### PR TITLE
Satisfiability check disabled by default, but can be enabled by parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,20 @@ ${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/
 make -C ${ZKLLVM_BUILD:-build} circuit_examples -j$(sysctl -n hw.logicalcpu)
 ${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.bc -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas
 ```
+
+### Validating the circuit
+
+You can also run the `assigner` with `--check` flag to validate the satisfiability of the circuit. If the circuit is satisfiable, the `assigner` will output the satisfying assignment in the `assignment.tbl` file. If there is an error, the `assigner` will output the error message and throw an exception via `std::abort`.
+
+#### Linux 
+
+```bash
+make -C ${ZKLLVM_BUILD:-build} circuit_examples -j$(nproc) 
+${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.bc -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas --check
+```
+
+#### macOS
+```bash
+make -C ${ZKLLVM_BUILD:-build} circuit_examples -j$(sysctl -n hw.logicalcpu)
+${ZKLLVM_BUILD:-build}/bin/assigner/assigner -b ${ZKLLVM_BUILD:-build}/examples/arithmetics_example.bc -i examples/arithmetics.inp -t assignment.tbl -c circuit.crct -e pallas --check
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,7 +49,7 @@ function(add_example example_target)
         set(binary_name ${example_target}.bc)
     endif()
     add_custom_target(${example_target}_run
-                      COMMAND $<TARGET_FILE:assigner> -b ${binary_name} -i ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_INPUT} -c circuit_${example_target}.crct -t assignment_${example_target}.tbl -e pallas
+                      COMMAND $<TARGET_FILE:assigner> -b ${binary_name} -i ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_INPUT} -c circuit_${example_target}.crct -t assignment_${example_target}.tbl -e pallas --check
                       DEPENDS ${example_target} ${ARG_INPUT} $<TARGET_FILE:assigner>
                       COMMAND_EXPAND_LISTS
                       VERBATIM)


### PR DESCRIPTION
--check parameter added to assigner for satisfiability check.
Now the satisfiability check is disabled by default, but can be enabled by this parameter.
It is done to prevent long assigner runs on huge circuits or public input. We faced long assigner runs before on Merkle Tree and zk-Bridges examples, which might be inconvenient for circuit developers.

Closes #125 