### PR TITLE
CI proving check added

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -104,14 +104,18 @@ jobs:
         run: |
           make -C build assigner clang transpiler -j$(nproc)
 
-      - name: Build examples
+      - name: Build IR of the examples
         run: |
           make -C build circuit_examples -j$(nproc)
           ls -al ./build/examples
 
-      - name: Build circuits
+      - name: Build circuit and assigner of the examples
         run: |
-          make -C build run_examples -j$(nproc)
+          make -C build assign_examples -j$(nproc)
+
+      - name: Build proof for the circuit of the examples
+        run: |
+          make -C build proof_examples -j$(nproc)
 
       - name: Build rslang
         run: |

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build proof for the circuit of the examples
         run: |
-          make -C build proof_examples -j$(nproc)
+          make -C build prove_examples -j$(nproc)
 
       - name: Build rslang
         run: |

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -87,4 +87,4 @@ jobs:
 
       - name: Build proof for the circuit of the examples
         run: |
-          make -C build proof_examples -j$(sysctl -n hw.logicalcpu)
+          make -C build prove_examples -j$(sysctl -n hw.logicalcpu)

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -76,10 +76,15 @@ jobs:
         run: |
           make -C build assigner clang transpiler -j$(sysctl -n hw.logicalcpu)
 
-      - name: Build examples
+      - name: Build IR of the examples
         run: |
           make -C build circuit_examples -j$(sysctl -n hw.logicalcpu)
+          ls -al ./build/examples
 
-      - name: Build circuits
+      - name: Build circuit and assigner of the examples
         run: |
-          make -C build run_examples -j$(sysctl -n hw.logicalcpu)
+          make -C build assign_examples -j$(sysctl -n hw.logicalcpu)
+
+      - name: Build proof for the circuit of the examples
+        run: |
+          make -C build proof_examples -j$(sysctl -n hw.logicalcpu)

--- a/bin/transpiler/CMakeLists.txt
+++ b/bin/transpiler/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(${CURRENT_PROJECT_NAME}
                       crypto3::random
                       crypto3::zk
 
+                      crypto3::assigner
                       crypto3::transpiler
 
                       marshalling::core

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_custom_target(circuit_examples)
-add_custom_target(run_examples)
+add_custom_target(assign_examples)
+add_custom_target(proof_examples)
 
 function(add_example example_target)
     set(prefix ARG)
@@ -48,12 +49,20 @@ function(add_example example_target)
     else()
         set(binary_name ${example_target}.bc)
     endif()
-    add_custom_target(${example_target}_run
+    
+    add_custom_target(${example_target}_assign
                       COMMAND $<TARGET_FILE:assigner> -b ${binary_name} -i ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_INPUT} -c circuit_${example_target}.crct -t assignment_${example_target}.tbl -e pallas
                       DEPENDS ${example_target} ${ARG_INPUT} $<TARGET_FILE:assigner>
                       COMMAND_EXPAND_LISTS
                       VERBATIM)
-    add_dependencies(run_examples ${example_target}_run)
+    add_dependencies(assign_examples ${example_target}_assign)
+
+    add_custom_target(${example_target}_proof
+                      COMMAND $<TARGET_FILE:transpiler> -m gen-test-proof -i ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_INPUT} -c circuit_${example_target}.crct -t assignment_${example_target}.tbl -o .
+                      DEPENDS ${example_target} ${ARG_INPUT} $<TARGET_FILE:transpiler>
+                      COMMAND_EXPAND_LISTS
+                      VERBATIM)
+    add_dependencies(proof_examples ${example_target}_proof)
 endfunction()
 
 add_example(arithmetics_example SOURCES arithmetics.cpp INPUT arithmetics.inp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(circuit_examples)
 add_custom_target(assign_examples)
-add_custom_target(proof_examples)
+add_custom_target(prove_examples)
 
 function(add_example example_target)
     set(prefix ARG)
@@ -57,12 +57,12 @@ function(add_example example_target)
                       VERBATIM)
     add_dependencies(assign_examples ${example_target}_assign)
 
-    add_custom_target(${example_target}_proof
+    add_custom_target(${example_target}_prove
                       COMMAND $<TARGET_FILE:transpiler> -m gen-test-proof -i ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_INPUT} -c circuit_${example_target}.crct -t assignment_${example_target}.tbl -o .
                       DEPENDS ${example_target} ${ARG_INPUT} $<TARGET_FILE:transpiler>
                       COMMAND_EXPAND_LISTS
                       VERBATIM)
-    add_dependencies(proof_examples ${example_target}_proof)
+    add_dependencies(prove_examples ${example_target}_prove)
 endfunction()
 
 add_example(arithmetics_example SOURCES arithmetics.cpp INPUT arithmetics.inp)


### PR DESCRIPTION
- Updated submodule `crypto3::math`, so we now have the last version of the proof system (this was the case of the bug #129)
- Changed the interface of the `transpiler`. Now it is more convenient to use it  right after `assigner`.
- `run_examples` target renamed to `assign_examples`. Added new target `prove_examples,` which runs `transpiler` on all the examples.
- Github actions extended with additional step: **Build proof for the circuit of the examples**.