### PR TITLE
ci: fix builds on macOS

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Configure CMake
         env:
-          BOOST_ROOT: "/usr/local/Cellar/boost@1.76/1.76.0_3"
+          BOOST_ROOT: "/usr/local/opt/boost@1.76"
           LDFLAGS: "-L/usr/local/opt/icu4c/lib"
           CPPFLAGS: "-I/usr/local/opt/icu4c/include"
         run: |


### PR DESCRIPTION
Minor updates in the Boost library result in version changes.
For example, current version is 1.76.0_4.
Paths under `/usr/local/Cellar/` contain the minor version, while
paths under `/usr/local/opt/` do not, so we can use them.


Resolves #137