### PR TITLE
Update zkllvm to pass flag to skip

### DIFF
--- a/bin/transpiler/src/main.cpp
+++ b/bin/transpiler/src/main.cpp
@@ -68,14 +68,15 @@ bool read_buffer_from_file(std::ifstream &ifile, std::vector<std::uint8_t> &v) {
 template<typename ProfilingType, typename ConstraintSystemType, typename ColumnsRotationsType,
          typename ArithmetizationParams>
 void print_sol_files(ConstraintSystemType &constraint_system, ColumnsRotationsType &columns_rotations,
-                     std::string out_folder_path = ".", bool optimize_gates = false) {
+                     std::string out_folder_path = ".", bool optimize_gates = false, bool generate_asm = true) {
     ProfilingType::process_split(
         nil::blueprint::main_sol_file_template,
         nil::blueprint::gate_sol_file_template,
         constraint_system, 
         columns_rotations, 
         out_folder_path,
-        optimize_gates
+        optimize_gates,
+        generate_asm
     );
 }
 
@@ -230,6 +231,7 @@ int main(int argc, char *argv[]) {
             ("output-folder-path,o", boost::program_options::value<std::string>(), "Output folder absolute path.\
             It'll be better to create an empty folder for output")
             ("optimize-gates", "Put multiple sequental small gates into one .sol file")
+            ("no-asm", "Skip optimised assembly/yul code generation")
             ;
     // clang-format on
 
@@ -248,6 +250,7 @@ int main(int argc, char *argv[]) {
     std::string circuit_file_name;
     std::string output_folder_path;
     std::string public_input;
+    bool generate_asm = true;
     
     if (vm.count("mode")) {
         mode = vm["mode"].as<std::string>();
@@ -291,6 +294,8 @@ int main(int argc, char *argv[]) {
         std::cout << options_desc << std::endl;
         return 1;
     }
+
+
 
     std::ifstream ifile;
     ifile.open(circuit_file_name);
@@ -378,8 +383,12 @@ int main(int argc, char *argv[]) {
         bool optimize_gates = false;
         if( vm.count("optimize-gates") )
             optimize_gates = true;
+        if(vm.count("no-asm")){
+            generate_asm = false ;
+        }
+
         print_sol_files<ProfilingType, ConstraintSystemType, ColumnsRotationsType, ArithmetizationParams>(
-            constraint_system, columns_rotations, output_folder_path, optimize_gates);
+            constraint_system, columns_rotations, output_folder_path, optimize_gates, generate_asm);
     }
 
     if ((mode == "gen-circuit-params") || (mode == "gen-test-proof")) {


### PR DESCRIPTION
This change adds a new flag `no-asm` which only works along with `optimise-gates` flag
This enables the transpiler to generate solidity code without assembly , which can be further used for downstream tools.

To be merged after zkllvm-transpiler is pushed and updated submods.