### PR TITLE
ci: Clean index.lock files

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -67,6 +67,11 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0
 
+      - name: Clean index.lock files if checkout step was cancelled or failed
+        if: cancelled() || failure()
+        run: |
+          find .git -name 'index.lock' -exec rm -v {} \;
+
       # Workaround: https://github.com/actions/checkout/issues/1169
       - name: Mark directory as safe
         run: |

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -3,19 +3,7 @@ name: build-linux
 on:
   push:
     branches: [ master ]
-    paths-ignore:
-      - '.github/workflows/*macos.yml'
-      - 'docs/**'
-      - '.clang-format'
-      - '.gitignore'
-      - 'README.md'
   pull_request:
-    paths-ignore:
-      - '.github/workflows/*macos.yml'
-      - 'docs/**'
-      - '.clang-format'
-      - '.gitignore'
-      - 'README.md'
 
 concurrency:
   group: ${{

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -3,19 +3,8 @@ name: build-macos
 on:
   push:
     branches: [ master ]
-    paths-ignore:
-      - '.github/workflows/*linux.yml'
-      - 'docs/**'
-      - '.clang-format'
-      - '.gitignore'
-      - 'README.md'
   pull_request:
-    paths-ignore:
-      - '.github/workflows/*linux.yml'
-      - 'docs/**'
-      - '.clang-format'
-      - '.gitignore'
-      - 'README.md'
+
 concurrency:
   group: ${{
     ( github.ref == 'refs/heads/master' &&


### PR DESCRIPTION
Cancelling a job while the checkout step is running often results in index.lock files persisting in one of the submodules. The checkout action only removes the index.lock files in the root repo, but not in submodules. (See issue https://github.com/actions/checkout/issues/1153). On the following job runs, checkout fails, being unable to operate on a submodule with an index.lock file.

This new step will remove such files when the job was cancelled or has failed on the checkout step or before it.

For details on the status check functions, used in this step, see
https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

Resolves #316

---

It was hard to reproduce the bug because we had to cancel the checkout step at a particular moment. However, we could mock it:

<img width="710" alt="Screenshot 2023-10-20 at 14 16 33" src="https://github.com/NilFoundation/zkllvm/assets/8015154/3a8e9d79-7635-4d50-b339-5455289c2f3f">
