### PR TITLE
Hotfix for MacOS CI workflow

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -34,12 +34,18 @@ jobs:
             spdlog \
             bash
 
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Print toolchain information
         run: |
           git --version
           cc --version
           cmake --version
           bash --version
+          python3 --version
           which -a bash
           echo PATH: $PATH
 


### PR DESCRIPTION
This PR should fix MacOS workflow, so it can become "required" again