### PR TITLE
Self hosted runners changed to the AWS autoscaling instances

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -23,7 +23,7 @@ jobs:
     secrets: inherit
 
   build-linux:
-    runs-on: [ self-hosted, Linux, amd64 ]
+    runs-on: [ self-hosted, Linux, X64, aws_autoscaling ]
 
     needs:
       - handle-syncwith

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   make-release:
-    runs-on: [ self-hosted, Linux, amd64 ]
+    runs-on: [ self-hosted, Linux, X64, aws_autoscaling ]
     environment: prod
 
     env:


### PR DESCRIPTION
DBMS team shared their autoscaling AWS instances with us. We can use them for Unix x64 tests.
For Mac, we only can use self-hosted machines, since AWS does not provide M1/M2 spot instances.