### PR TITLE
Bump version of recursive-checkout in CI scripts

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Checkout modules to specified refs
         if: needs.handle-syncwith.outputs.prs-refs != ''
-        uses: NilFoundation/ci-cd/actions/recursive-checkout@v1
+        uses: NilFoundation/ci-cd/actions/recursive-checkout@v1.2.1
         # TODO: figure out the mapping of volumes and use variable here, not hardcoded path
         with:
           paths: |

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkout modules to specified refs
         if: needs.handle-syncwith.outputs.prs-refs != ''
-        uses: NilFoundation/ci-cd/actions/recursive-checkout@v1
+        uses: NilFoundation/ci-cd/actions/recursive-checkout@v1.2.1
         with:
           paths: |
             ${{ github.workspace }}/**


### PR DESCRIPTION
This fixes some issues with checkouting modules like this:

https://github.com/NilFoundation/zkLLVM/actions/runs/7919099947 